### PR TITLE
Improve collector freshness and stream recovery

### DIFF
--- a/src/collectors/bandwidth.js
+++ b/src/collectors/bandwidth.js
@@ -45,6 +45,7 @@ class BandwidthCollector {
     this._stopping    = false;
     this.lastPayload  = null;
     this._lastFp      = '';
+    this._lastEmitTs  = 0;
     this._lastSnapshotTs = 0; // tracks the connTableCache snapshot timestamp to detect cache hits
     this._lastIfaceTs    = 0; // fingerprint to detect ifStatus payload changes for cache invalidation
     // Set to true by start(), never reset. Allows the connected handler to
@@ -61,6 +62,7 @@ class BandwidthCollector {
       this._orgCache.clear();
       this._ifaceCache.clear();
       this._lastFp = '';
+      this._lastEmitTs = 0;
       this._lastSnapshotTs = 0;
       // Only restart here on reconnect after a close. On the very first
       // connect, startCollectors() in index.js calls start() explicitly —
@@ -257,8 +259,9 @@ class BandwidthCollector {
 
     this.lastPayload = { ts: now, devices, pollMs: this.pollMs };
     const fp = JSON.stringify(devices.map(d => ({ src: d.srcIp, rx: d.rxMbps, tx: d.txMbps })));
-    if (fp !== this._lastFp) {
+    if (fp !== this._lastFp || now - this._lastEmitTs >= 10000) {
       this._lastFp = fp;
+      this._lastEmitTs = now;
       this.io.to('page-bandwidth').to('dash-card-bandwidth').emit('bandwidth:update', this.lastPayload);
     }
     this.state.lastBandwidthTs  = now;

--- a/src/collectors/interfaceStatus.js
+++ b/src/collectors/interfaceStatus.js
@@ -50,6 +50,9 @@ class InterfaceStatusCollector {
     this._ratesTimer   = null;
     this._ratesInflight = false;
     this._lastFp       = '';
+    this._lastEmitTs   = 0;
+    this._lastRatesSuccessTs = 0;
+    this._lastPollErrLogTs = 0;
     this.lastPayload   = null;
 
     this.ros.on('close', () => {
@@ -97,9 +100,19 @@ class InterfaceStatusCollector {
             txMbps: bpsToMbps(parseBps(r['tx-bits-per-second'])),
           });
         }
+        const now = Date.now();
+        this._lastRatesSuccessTs = now;
+        this.state.lastIfStatusTs = now;
+        this.state.lastIfStatusErr = null;
       }
     } catch (e) {
-      // Suppress — rates simply stay at last known value until next poll
+      const msg = e && e.message ? e.message : String(e);
+      this.state.lastIfStatusErr = msg;
+      const now = Date.now();
+      if (now - this._lastPollErrLogTs >= 60000) {
+        this._lastPollErrLogTs = now;
+        console.error(this._lbl + ' monitor-traffic poll error:', msg); // codeql[js/tainted-format-string]
+      }
     } finally {
       this._ratesInflight = false;
     }
@@ -264,6 +277,10 @@ class InterfaceStatusCollector {
         rxMbps: bpsToMbps(parseBps(packet['rx-bits-per-second'])),
         txMbps: bpsToMbps(parseBps(packet['tx-bits-per-second'])),
       });
+      const now = Date.now();
+      this._lastRatesSuccessTs = now;
+      this.state.lastIfStatusTs = now;
+      this.state.lastIfStatusErr = null;
     });
     stream.on('error', (err) => {
       const msg = err && err.message ? err.message : String(err);
@@ -357,13 +374,12 @@ class InterfaceStatusCollector {
       ips: i.ips,
     })));
     this.lastPayload = { ts: now, interfaces };
-    // Healthy tick — advance ts / clear err even when nothing changed, and keep
-    // lastPayload fresh for replay while idle; only the emit is gated below.
-    this.state.lastIfStatusTs  = now;
-    this.state.lastIfStatusErr = null;
     if (this.io.engine.clientsCount === 0) return;
-    if (fp === this._lastFp) return;
+    // Re-emit a heartbeat even when rates are unchanged so the browser can
+    // distinguish an idle interface from a dead collector.
+    if (fp === this._lastFp && now - this._lastEmitTs < 60000) return;
     this._lastFp = fp;
+    this._lastEmitTs = now;
     this.io.emit('ifstatus:update', this.lastPayload);
   }
 

--- a/src/collectors/traffic.js
+++ b/src/collectors/traffic.js
@@ -35,6 +35,9 @@ class TrafficCollector {
     this.availableIfs  = new Set();  // validated set from fetchInterfaces()
     this._loggedErr    = false;
     this._restartTimer = null;
+    this._watchdogTimer = null;
+    this._streamStartTs = 0;
+    this._lastDataTs    = 0;
     this.lastWanStatus = null;
 
     this.ros.on('connected', () => {
@@ -42,8 +45,12 @@ class TrafficCollector {
       this._stopAllStream();
       this._ensureHistory(this.defaultIf);
       this._updateStream();
+      this._startWatchdog();
     });
-    this.ros.on('close', () => this._stopAllStream());
+    this.ros.on('close', () => {
+      this._stopAllStream();
+      this._stopWatchdog();
+    });
   }
 
   _ensureHistory(ifName) {
@@ -94,9 +101,13 @@ class TrafficCollector {
 
   _stopAllStream() {
     if (this._restartTimer) { clearTimeout(this._restartTimer); this._restartTimer = null; }
-    if (!this._allStream) return;
+    if (!this._allStream) {
+      this._streamStartTs = 0;
+      return;
+    }
     stopStreamSafe(this._allStream);
     this._allStream = null;
+    this._streamStartTs = 0;
     console.log(this._lbl + ' stopped stream');
   }
 
@@ -105,6 +116,8 @@ class TrafficCollector {
     if (!this.ros.connected) return;
 
     const names = this._getStreamNames();
+    this._streamStartTs = Date.now();
+    this._lastDataTs = 0;
     console.log(this._lbl + ' streaming', names.length, 'interface(s) interval=1s'); // codeql[js/tainted-format-string]
 
     const stream = this.ros.stream(
@@ -122,7 +135,10 @@ class TrafficCollector {
       // When a single interface is monitored, RouterOS may omit the 'name' field.
       const ifName = packet.name || (names.length === 1 ? names[0] : null);
       if (!ifName) return;
-      if (!packet['rx-bits-per-second'] && !packet['tx-bits-per-second']) return;
+      const hasRx = Object.prototype.hasOwnProperty.call(packet, 'rx-bits-per-second');
+      const hasTx = Object.prototype.hasOwnProperty.call(packet, 'tx-bits-per-second');
+      if (!hasRx && !hasTx) return;
+      this._lastDataTs = Date.now();
       this._processPacket(ifName, packet);
     });
 
@@ -148,6 +164,30 @@ class TrafficCollector {
     });
 
     this._allStream = stream;
+  }
+
+  _startWatchdog() {
+    this._stopWatchdog();
+    const staleMs = 10000;
+    this._watchdogTimer = setInterval(() => {
+      if (!this.ros.connected || this._restartTimer) return;
+      if (!this._allStream) {
+        console.warn(this._lbl + ' watchdog: stream missing — restarting');
+        this._startAllStream();
+        return;
+      }
+      const last = this._lastDataTs || this._streamStartTs;
+      if (last && Date.now() - last > staleMs) {
+        console.warn(this._lbl + ' watchdog: no data for ' + Math.round((Date.now() - last) / 1000) + 's — restarting stream');
+        this._stopAllStream();
+        this._startAllStream();
+      }
+    }, 5000);
+  }
+
+  _stopWatchdog() {
+    if (this._watchdogTimer) clearInterval(this._watchdogTimer);
+    this._watchdogTimer = null;
   }
 
   bindSocket(socket) {
@@ -212,6 +252,12 @@ class TrafficCollector {
     this._ensureHistory(ifName);
     this.hist.get(ifName).push({ ts: now, rx_mbps: rxMbps, tx_mbps: txMbps });
 
+    // Collector health must advance even with no browser connected. Previously
+    // this happened after the idle gate, so a healthy stream looked stale.
+    this.state.lastTrafficTs  = now;
+    this.state.lastTrafficErr = null;
+    this._loggedErr = false;
+
     if (this.io.engine.clientsCount === 0) return;
 
     const sample = { ifName, ts: now, rx_mbps: rxMbps, tx_mbps: txMbps, running, disabled };
@@ -224,18 +270,17 @@ class TrafficCollector {
       this.io.emit('wan:status', this.lastWanStatus);
     }
 
-    this.state.lastTrafficTs  = now;
-    this.state.lastTrafficErr = null;
-    this._loggedErr = false;
   }
 
   start() {
     this._ensureHistory(this.defaultIf);
     this._startAllStream();
+    this._startWatchdog();
   }
 
   stop() {
     this._stopAllStream();
+    this._stopWatchdog();
     // Release socket listeners/references so a torn-down session can be GC'd.
     for (const { socket, onSelect, onDisconnect } of this._boundSockets.values()) {
       socket.off('traffic:select', onSelect);

--- a/src/health.js
+++ b/src/health.js
@@ -1,9 +1,29 @@
-function computeHealthStatus({ startupReady, rosConnected }) {
-  const ok = !!startupReady && !!rosConnected;
+const DEFAULT_FRESHNESS_MS = {
+  traffic:  20000,
+  system:   30000,
+  ifstatus: 120000,
+};
+
+function computeHealthStatus({ startupReady, rosConnected, state = {}, now = Date.now(), freshnessMs = DEFAULT_FRESHNESS_MS, requiredCollectors = ['traffic'] }) {
+  const stale = [];
+  if (startupReady && rosConnected) {
+    const checks = {
+      traffic: state.lastTrafficTs,
+      system: state.lastSystemTs,
+      ifstatus: state.lastIfStatusTs,
+    };
+    for (const name of requiredCollectors) {
+      const ts = checks[name];
+      const maxAge = freshnessMs[name];
+      if (!Number.isFinite(maxAge) || !Number.isFinite(ts) || ts <= 0 || now - ts > maxAge) stale.push(name);
+    }
+  }
+  const ok = !!startupReady && !!rosConnected && stale.length === 0;
   return {
     ok,
     statusCode: ok ? 200 : 503,
+    stale,
   };
 }
 
-module.exports = { computeHealthStatus };
+module.exports = { computeHealthStatus, DEFAULT_FRESHNESS_MS };

--- a/src/index.js
+++ b/src/index.js
@@ -1606,11 +1606,21 @@ function sanitizeErr(e) {
 app.get('/healthz', (req, res) => {
   const ge = _globalEntry();
   const s  = ge ? ge.session : null;
-  const { ok, statusCode } = computeHealthStatus({
+  const st = s ? s.state : {};
+  const activeRoomSize = s ? (io.sockets.adapter.rooms.get('router-' + s.routerId)?.size || 0) : 0;
+  // High-frequency system/interface collectors are intentionally suspended
+  // while nobody is viewing this router. Traffic remains active for history
+  // recording, so it is always required; add viewer-driven collectors only
+  // while their suspension would be unexpected.
+  const requiredCollectors = activeRoomSize > 0
+    ? ['traffic', 'system', 'ifstatus']
+    : ['traffic'];
+  const { ok, statusCode, stale } = computeHealthStatus({
     startupReady: ge ? ge.startupReady : false,
     rosConnected: s ? s.ros.connected : false,
+    state: st,
+    requiredCollectors,
   });
-  const st = s ? s.state : {};
   const isStarting = !(ge && ge.startupReady) && (Date.now() - _serverStartTime < STARTUP_GRACE_MS);
   // Unauthenticated callers (the Docker healthcheck) only need the status code
   // and ok/starting flags — version, router ids and collector detail would
@@ -1625,6 +1635,7 @@ app.get('/healthz', (req, res) => {
     routerConnected: s ? s.ros.connected : false,
     activeRouterId:  s ? s.routerId : null,
     startupReady: ge ? ge.startupReady : false,
+    stale,
     uptime: process.uptime(),
     now: Date.now(),
     defaultIf: s ? s.DEFAULT_IF : '',

--- a/src/routeros/client.js
+++ b/src/routeros/client.js
@@ -1,8 +1,9 @@
 /**
  * MikroDash RouterOS client — node-routeros wrapper v0.3.3
  *
- * node-routeros stream() signature:
- *   conn.stream(wordsArray, callback)   ← two args only, no params array
+ * node-routeros stream() accepts a flattened words array.  This wrapper also
+ * supports the write()-style three-argument form used by collectors:
+ *   stream(command, paramsArray, callback)
  *
  * node-routeros write() signature:
  *   conn.write(cmd, paramsArray)        ← cmd string + optional array of '=k=v' strings
@@ -180,10 +181,17 @@ class ROS extends EventEmitter {
    *   callback   — function(err, data) called on every !re sentence
    * Returns a Stream object with .stop(), .pause(), .resume() methods.
    */
-  stream(words, callback) {
+  stream(words, paramsOrCallback, callback) {
     if (!this.conn || !this.connected) throw new Error('Not connected');
-    if (!Array.isArray(words)) words = [words];
-    return this.conn.stream(words, callback);
+    const wordsArr = Array.isArray(words) ? [...words] : [words];
+    let cb = null;
+
+    if (Array.isArray(paramsOrCallback)) wordsArr.push(...paramsOrCallback);
+    else if (typeof paramsOrCallback === 'string') wordsArr.push(paramsOrCallback);
+    else if (typeof paramsOrCallback === 'function') cb = paramsOrCallback;
+
+    if (typeof callback === 'function') cb = callback;
+    return this.conn.stream(wordsArr, cb);
   }
 
   stop() {

--- a/test/code-review-remediation.test.js
+++ b/test/code-review-remediation.test.js
@@ -13,6 +13,7 @@ const path = require('path');
 const ROS                  = require('../src/routeros/client');
 const ConnectionsCollector = require('../src/collectors/connections');
 const TrafficCollector     = require('../src/collectors/traffic');
+const InterfaceStatusCollector = require('../src/collectors/interfaceStatus');
 const TopTalkersCollector  = require('../src/collectors/talkers');
 const WirelessCollector    = require('../src/collectors/wireless');
 const PingCollector        = require('../src/collectors/ping');
@@ -93,6 +94,24 @@ test('routerLabel passes ordinary labels through unchanged and handles null', ()
   assert.ok(!fresh.routerLabel, 'unset label is falsy');
   ros.routerLabel = null;
   assert.equal(ros.routerLabel, '');
+});
+
+test('ROS stream supports command, params array, callback without dropping words', () => {
+  const ros = new ROS({});
+  ros.connected = true;
+  let forwardedWords = null;
+  let forwardedCb = null;
+  ros.conn = {
+    stream(words, cb) {
+      forwardedWords = words;
+      forwardedCb = cb;
+      return { stop() {} };
+    },
+  };
+  const cb = () => {};
+  ros.stream('/interface/monitor-traffic', ['=interface=wan', '=interval=1'], cb);
+  assert.deepEqual(forwardedWords, ['/interface/monitor-traffic', '=interface=wan', '=interval=1']);
+  assert.equal(forwardedCb, cb);
 });
 
 // ── ROS client: listener exceptions must not kill connectLoop ────────────────
@@ -221,6 +240,44 @@ test('traffic bindSocket attaches listeners once per socket; unbind/stop release
   assert.equal(sock.listenerCount('traffic:select'), 0, 'stop() releases socket listeners');
   assert.equal(t.subscriptions.size, 0);
   assert.equal(t._boundSockets.size, 0);
+});
+
+test('traffic watchdog restarts a silently stalled stream', async () => {
+  await withPatchedTimers(async (timers) => {
+    const ros = mockStreamRos();
+    const t = new TrafficCollector({ ros, io: stubIo(0), defaultIf: 'wan', historyMinutes: 1, pollMs: 1000, state: {} });
+    t.start();
+    const first = t._allStream;
+    t._streamStartTs = Date.now() - 11000;
+    t._lastDataTs = 0;
+    const watchdog = timers.find(timer => timer.isInterval && timer.ms === 5000 && !timer.cleared);
+    assert.ok(watchdog, 'traffic watchdog armed');
+    watchdog.cb();
+    assert.notEqual(t._allStream, first, 'stalled stream replaced');
+    t.stop();
+  });
+});
+
+test('traffic stream accepts numeric zero counters as a healthy idle sample', () => {
+  const ros = mockStreamRos();
+  const state = {};
+  const t = new TrafficCollector({ ros, io: stubIo(0), defaultIf: 'wan', historyMinutes: 1, pollMs: 1000, state });
+  t.start();
+  t._allStream.emit('data', { 'rx-bits-per-second': 0, 'tx-bits-per-second': 0 });
+  assert.ok(state.lastTrafficTs > 0, 'idle zero-rate packet advances freshness');
+  t.stop();
+});
+
+test('interface rate poll records errors without advancing freshness', async () => {
+  const state = { lastIfStatusTs: 123 };
+  const ros = new EventEmitter();
+  ros.connected = true;
+  ros.write = async () => { throw new Error('monitor failed'); };
+  const collector = new InterfaceStatusCollector({ ros, io: stubIo(1), pollMs: 1000, state, streamMode: false });
+  collector._ifaces.set('wan', { name: 'wan', disabled: false });
+  await collector._pollRatesOnce();
+  assert.equal(state.lastIfStatusTs, 123, 'failed poll does not look fresh');
+  assert.match(state.lastIfStatusErr, /monitor failed/);
 });
 
 // ── Empty-table stream packets ───────────────────────────────────────────────

--- a/test/production-resilience-regressions.test.js
+++ b/test/production-resilience-regressions.test.js
@@ -36,22 +36,53 @@ test('buildHelmetOptions uses a self-hosted CSP policy', () => {
   assert.ok(!allSrcs.some(s => s === 'fonts.googleapis.com' || s.endsWith('.fonts.googleapis.com')), 'CSP must not allow Google Fonts');
 });
 
-test('computeHealthStatus reports readiness from startup and connectivity, not traffic freshness', () => {
+test('computeHealthStatus requires startup, connectivity, and fresh critical collectors', () => {
   const { computeHealthStatus } = require('../src/health');
+  const now = 1_000_000;
 
-  // state is passed intentionally — proves traffic freshness doesn't influence health
   const ready = computeHealthStatus({
     startupReady: true,
     rosConnected: true,
-    state: { lastTrafficTs: 0 },
+    now,
+    state: {
+      lastTrafficTs: now - 1000,
+      lastSystemTs: now - 1000,
+      lastIfStatusTs: now - 1000,
+    },
+    requiredCollectors: ['traffic', 'system', 'ifstatus'],
   });
   assert.equal(ready.ok, true);
   assert.equal(ready.statusCode, 200);
+  assert.deepEqual(ready.stale, []);
+
+  const staleTraffic = computeHealthStatus({
+    startupReady: true,
+    rosConnected: true,
+    now,
+    state: {
+      lastTrafficTs: now - 30000,
+      lastSystemTs: now - 1000,
+      lastIfStatusTs: now - 1000,
+    },
+    requiredCollectors: ['traffic', 'system', 'ifstatus'],
+  });
+  assert.equal(staleTraffic.ok, false);
+  assert.equal(staleTraffic.statusCode, 503);
+  assert.deepEqual(staleTraffic.stale, ['traffic']);
+
+  const idle = computeHealthStatus({
+    startupReady: true,
+    rosConnected: true,
+    now,
+    state: { lastTrafficTs: now - 1000, lastSystemTs: 0, lastIfStatusTs: 0 },
+  });
+  assert.equal(idle.ok, true, 'intentionally suspended viewer collectors are optional by default');
 
   const booting = computeHealthStatus({
     startupReady: false,
     rosConnected: true,
-    state: { lastTrafficTs: Date.now() },
+    now,
+    state: {},
   });
   assert.equal(booting.ok, false);
   assert.equal(booting.statusCode, 503);
@@ -59,7 +90,8 @@ test('computeHealthStatus reports readiness from startup and connectivity, not t
   const disconnected = computeHealthStatus({
     startupReady: true,
     rosConnected: false,
-    state: { lastTrafficTs: Date.now() },
+    now,
+    state: {},
   });
   assert.equal(disconnected.ok, false);
   assert.equal(disconnected.statusCode, 503);


### PR DESCRIPTION
## What changed

- add a watchdog that restarts a silently stalled WAN traffic stream
- make health checks validate freshness for collectors that are expected to be active
- record interface-rate polling failures instead of silently retaining stale/zero values
- stop failed interface polls from advancing the collector freshness timestamp
- add heartbeat emissions for unchanged interface and per-device bandwidth data
- explicitly support `stream(command, params, callback)` in the RouterOS wrapper
- add regression tests for recovery, freshness, zero-rate samples, and stream argument forwarding

## Root cause

Persistent RouterOS streams can remain attached without delivering further samples. The traffic collector previously had no watchdog, and `/healthz` only checked the parent RouterOS connection. Separately, interface poll errors were suppressed while `_buildAndEmit()` continued advancing `lastIfStatusTs`, making a failed collector appear healthy.

This matches the symptoms reported in #55 and #90: interface rates remain at zero or graphs stop after a few seconds while the application remains connected.

## Behaviour after this change

- the fixed one-second WAN stream is restarted after ten seconds without data
- `/healthz` reports stale critical collectors while they are expected to run
- collectors intentionally suspended with no active viewers are excluded from freshness requirements
- idle interfaces that legitimately report numeric zero counters remain healthy
- unchanged UI data receives periodic heartbeats instead of being marked stale

## Validation

- full Node test suite passed on a branch based directly on `upstream/main`
- focused regression suite: 27 tests passed
- `git diff --check` passed
