### PR TITLE
Fix missing action status handlers on WAN, Queues, and Router Users

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -12991,6 +12991,15 @@ function _renderRoutersMap(rows) {
   var _caps = { permitted: false, routerName: '' };
   var _busy = '';
 
+  var _statusTimer = null;
+  function setStatus(text) {
+    var el = $('wanActionNote');
+    if (!el) return;
+    el.textContent = text || '';
+    if (_statusTimer) clearTimeout(_statusTimer);
+    if (text) _statusTimer = setTimeout(function () { el.textContent = ''; }, 8000);
+  }
+
   var COLS = [{key:'',label:'Uplink'},{key:'',label:'Address'},{key:'',label:'Gateway'},
               {key:'',label:'Route'},{key:'',label:'Lease'},{key:'',label:'Rate'},{key:'',label:''}];
 
@@ -13222,6 +13231,15 @@ function _renderRoutersMap(rows) {
   var _caps = { permitted: false, routerName: '' };
   var _tab  = 'simple';
   var _busy = '';
+
+  var _statusTimer = null;
+  function setStatus(text) {
+    var el = $('qActionNote');
+    if (!el) return;
+    el.textContent = text || '';
+    if (_statusTimer) clearTimeout(_statusTimer);
+    if (text) _statusTimer = setTimeout(function () { el.textContent = ''; }, 8000);
+  }
 
   // Order first, and it is not cosmetic — see the header.
   var SIMPLE_COLS = [{key:'',label:'#'},{key:'name',label:'Name'},{key:'target',label:'Target'},
@@ -13688,6 +13706,15 @@ function _renderRoutersMap(rows) {
   var _caps = { permitted: false, routerName: '' };
   var _tab  = 'users';
   var _busy = '';          // id of the row with an action in flight
+
+  var _statusTimer = null;
+  function setStatus(text) {
+    var el = $('ruActionNote');
+    if (!el) return;
+    el.textContent = text || '';
+    if (_statusTimer) clearTimeout(_statusTimer);
+    if (text) _statusTimer = setTimeout(function () { el.textContent = ''; }, 8000);
+  }
 
   // A keyless column is not sortable — see _renderSortHeader. The action column
   // is the only one here that must never be.

--- a/test/resource-writes.test.js
+++ b/test/resource-writes.test.js
@@ -845,3 +845,22 @@ test('the gap is the same red as the drop pill, carried by colour alone', () => 
   assert.ok(!/border/.test(cell), 'colour alone — no border on the gap cell');
   assert.ok(!/!important/.test(cell), 'and so no !important needed');
 });
+
+test('each write page owns the status handler its socket callbacks call', () => {
+  // setStatus in the Packages IIFE is not visible to the three IIFEs below it.
+  // Without a local handler, a successful write completes on RouterOS and then
+  // throws ReferenceError in the browser instead of reporting the result.
+  const pages = [
+    ['── WAN page', '── Queues page', 'wanActionNote'],
+    ['── Queues page', '── Router Users page', 'qActionNote'],
+    ['── Router Users page', '── Audit page', 'ruActionNote'],
+  ];
+  for (const [start, end, noteId] of pages) {
+    const at = APP.indexOf(start);
+    const to = APP.indexOf(end, at);
+    assert.ok(at > 0 && to > at, `found ${start}`);
+    const block = APP.slice(at, to);
+    assert.match(block, /function setStatus\(text\)/, `${start} needs a local setStatus`);
+    assert.ok(block.includes(`$('${noteId}')`), `${start} writes to ${noteId}`);
+  }
+});


### PR DESCRIPTION
## Problem
The WAN, Queues, and Router Users socket callbacks call `setStatus(...)`, but the only implementation is scoped inside the preceding Packages IIFE. A successful action can therefore complete on RouterOS and then throw `ReferenceError: setStatus is not defined` in the browser instead of showing its result.

## Fix
- Give each page its own small status handler, targeting the existing `wanActionNote`, `qActionNote`, and `ruActionNote` elements.
- Clear messages after 8 seconds, matching the Packages page behavior.
- Add a source-shape regression that keeps each handler inside the IIFE that calls it.

## Verification
- `node --test test/resource-writes.test.js` — 76 passed
- `npm run lint` — 0 errors
- `git diff --check` — passed