### PR TITLE
Fail closed when node-routeros compatibility patches are incomplete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache python3 make g++
 COPY package*.json ./
 RUN npm install --omit=dev --no-audit --no-fund
 # Patch node-routeros to handle RouterOS 7.18+ !empty API reply
+COPY src/routeros/patchVerification.js ./src/routeros/patchVerification.js
 COPY patch-routeros.js ./
 RUN node patch-routeros.js
 COPY . .

--- a/patch-routeros.js
+++ b/patch-routeros.js
@@ -18,18 +18,25 @@
 'use strict';
 const fs   = require('fs');
 const path = require('path');
+const {
+  PATCH_MARKERS,
+  resolveDistPath,
+  hasExactPatchMarker,
+} = require('./src/routeros/patchVerification');
 
 const BASE = path.join(__dirname, 'node_modules', 'node-routeros', 'dist');
+let patchFailed = false;
 
 function patch(filePath, description, replacements) {
   if (!fs.existsSync(filePath)) {
     console.warn('[patch] File not found, skipping:', filePath);
+    patchFailed = true;
     return false;
   }
 
   let src = fs.readFileSync(filePath, 'utf8');
 
-  if (src.includes('MIKRODASH_PATCHED_' + description)) {
+  if (hasExactPatchMarker(src, 'MIKRODASH_PATCHED_' + description)) {
     console.log('[patch]', description, '— already applied, skipping');
     return true;
   }
@@ -44,7 +51,8 @@ function patch(filePath, description, replacements) {
 
   if (applied === 0) {
     console.warn('[patch]', description, '— target string not found (library version mismatch?)');
-    console.warn('[patch] App will start but may crash on edge cases. File:', filePath);
+    console.warn('[patch] Refusing an unverified dependency build. File:', filePath);
+    patchFailed = true;
     return false;
   }
 
@@ -273,10 +281,11 @@ patch(
   const channelPath = path.join(BASE, 'Channel.js');
   if (!fs.existsSync(channelPath)) {
     console.warn('[patch] MULTI_BLOCK_V2 — Channel.js not found');
+    patchFailed = true;
     return;
   }
   let src = fs.readFileSync(channelPath, 'utf8');
-  if (src.includes('MIKRODASH_PATCHED_MULTI_BLOCK_V2')) {
+  if (hasExactPatchMarker(src, 'MIKRODASH_PATCHED_MULTI_BLOCK_V2')) {
     console.log('[patch] MULTI_BLOCK_V2 — already applied, skipping');
     return;
   }
@@ -286,6 +295,7 @@ patch(
   const replace = `        if (this.trapped) { this.close(); break; } // MIKRODASH_PATCHED_MULTI_BLOCK_V2\n                if (this.streaming) break;\n                if (this._doneTimer) clearTimeout(this._doneTimer);`;
   if (!src.includes(find)) {
     console.warn('[patch] MULTI_BLOCK_V2 — target not found (MULTI_BLOCK not applied or format changed)');
+    patchFailed = true;
     return;
   }
   fs.writeFileSync(channelPath, src.replace(find, replace), 'utf8');
@@ -321,4 +331,32 @@ patch(
   ]
 );
 
-console.log('[patch] Done.');
+// A successful npm install is not enough: this archived dependency is safe for
+// MikroDash only with every required compatibility patch. Docker builds and CI
+// must fail closed if a dependency update makes a marker or behavior disappear.
+const required = PATCH_MARKERS.map(marker => [path.join(BASE, resolveDistPath(marker)), marker]);
+for (const [file, marker] of required) {
+  let source = '';
+  try { source = fs.readFileSync(file, 'utf8'); } catch (_) { /* handled below */ }
+  if (!hasExactPatchMarker(source, marker)) {
+    console.error('[patch] REQUIRED marker missing:', marker, 'in', file);
+    patchFailed = true;
+  }
+}
+const channelSource = fs.existsSync(path.join(BASE, 'Channel.js'))
+  ? fs.readFileSync(path.join(BASE, 'Channel.js'), 'utf8') : '';
+const emptyReplySafe = channelSource.includes(
+  "if (reply === '!empty') { if (this.streaming) return; this.emit('done', []); return; }"
+);
+const emptyDefaultSafe = /if \(reply === '!empty'\) \{\s*if \(this\.streaming\) break;\s*this\.emit\('done', this\.data\);\s*this\.close\(\);\s*break;/m
+  .test(channelSource);
+if (!emptyReplySafe || !emptyDefaultSafe || !channelSource.includes('if (this.streaming) break;')) {
+  console.error('[patch] REQUIRED patched behavior verification failed');
+  patchFailed = true;
+}
+if (patchFailed) {
+  console.error('[patch] FAILED — refusing to continue with an unverified node-routeros build.');
+  process.exitCode = 1;
+} else {
+  console.log('[patch] Done — all required markers and behaviors verified.');
+}

--- a/src/routeros/patchVerification.js
+++ b/src/routeros/patchVerification.js
@@ -1,13 +1,15 @@
 const path = require('path');
 
 // Which file each marker must appear in. Spelled out rather than derived from
-// the marker's name: the mapping used to be a substring test, and it worked
-// only because every marker but one lived in Receiver.js. Patch 6 put a marker
-// in Transmitter.js, which a substring test has no way to see.
+// the marker's name so every compatibility patch is verified in the file it
+// actually modifies.
 const PATCH_FILES = {
   MIKRODASH_PATCHED_EMPTY_REPLY:     'Channel.js',
+  MIKRODASH_PATCHED_EMPTY_NO_CLOSE:  'Channel.js',
   MIKRODASH_PATCHED_UNREGISTEREDTAG: path.join('connector', 'Receiver.js'),
   MIKRODASH_PATCHED_RAW_BYTES:       path.join('connector', 'Receiver.js'),
+  MIKRODASH_PATCHED_MULTI_BLOCK:     'Channel.js',
+  MIKRODASH_PATCHED_MULTI_BLOCK_V2:  'Channel.js',
   MIKRODASH_PATCHED_UTF8_ENCODE:     path.join('connector', 'Transmitter.js'),
 };
 
@@ -15,6 +17,14 @@ const PATCH_MARKERS = Object.keys(PATCH_FILES);
 
 function resolveDistPath(marker) {
   return PATCH_FILES[marker] || path.join('connector', 'Receiver.js');
+}
+
+function hasExactPatchMarker(src, marker) {
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Markers may be a standalone comment or an inline end-of-line comment.
+  // Token boundaries are deliberate: MULTI_BLOCK_V2 must never satisfy the
+  // required MULTI_BLOCK marker merely because it shares that prefix.
+  return new RegExp(`(?:^|[^A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`, 'm').test(src);
 }
 
 function verifyRouterOSPatchMarkers({
@@ -36,7 +46,7 @@ function verifyRouterOSPatchMarkers({
       throw new Error(msg);
     }
 
-    if (!src.includes(marker)) {
+    if (!hasExactPatchMarker(src, marker)) {
       const msg = `[MikroDash] CRITICAL: node-routeros patch "${marker}" not found in ${target}`;
       log.error(msg);
       throw new Error(msg);
@@ -47,5 +57,6 @@ function verifyRouterOSPatchMarkers({
 module.exports = {
   PATCH_MARKERS,
   resolveDistPath,
+  hasExactPatchMarker,
   verifyRouterOSPatchMarkers,
 };

--- a/test/production-resilience-regressions.test.js
+++ b/test/production-resilience-regressions.test.js
@@ -1,7 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const ROS = require('../src/routeros/client');
 const ConnectionsCollector = require('../src/collectors/connections');
@@ -136,6 +138,70 @@ test('verifyRouterOSPatchMarkers throws when a patch file cannot be read', () =>
     }),
     /Could not verify patch .*ENOENT/i
   );
+});
+
+test('all node-routeros compatibility patches are required at startup', () => {
+  const { PATCH_MARKERS, resolveDistPath, hasExactPatchMarker } = require('../src/routeros/patchVerification');
+  assert.deepEqual(PATCH_MARKERS, [
+    'MIKRODASH_PATCHED_EMPTY_REPLY',
+    'MIKRODASH_PATCHED_EMPTY_NO_CLOSE',
+    'MIKRODASH_PATCHED_UNREGISTEREDTAG',
+    'MIKRODASH_PATCHED_RAW_BYTES',
+    'MIKRODASH_PATCHED_MULTI_BLOCK',
+    'MIKRODASH_PATCHED_MULTI_BLOCK_V2',
+    'MIKRODASH_PATCHED_UTF8_ENCODE',
+  ]);
+  assert.equal(resolveDistPath('MIKRODASH_PATCHED_MULTI_BLOCK_V2'), 'Channel.js');
+  assert.equal(hasExactPatchMarker('// MIKRODASH_PATCHED_MULTI_BLOCK_V2\n',
+    'MIKRODASH_PATCHED_MULTI_BLOCK'), false, 'V2 cannot satisfy the V1 marker');
+  assert.equal(hasExactPatchMarker('if (this.streaming) break; // MIKRODASH_PATCHED_MULTI_BLOCK_V2',
+    'MIKRODASH_PATCHED_MULTI_BLOCK_V2'), true, 'inline end-of-line markers are valid');
+  assert.equal(hasExactPatchMarker('xMIKRODASH_PATCHED_MULTI_BLOCK',
+    'MIKRODASH_PATCHED_MULTI_BLOCK'), false, 'an identifier prefix is not a token boundary');
+  assert.equal(hasExactPatchMarker('MIKRODASH_PATCHED_MULTI_BLOCKx',
+    'MIKRODASH_PATCHED_MULTI_BLOCK'), false, 'an identifier suffix is not a token boundary');
+});
+
+test('patch verification fails when only MULTI_BLOCK_V2 is present', () => {
+  const { verifyRouterOSPatchMarkers } = require('../src/routeros/patchVerification');
+  assert.throws(() => verifyRouterOSPatchMarkers({
+    patchMarkers: ['MIKRODASH_PATCHED_MULTI_BLOCK'],
+    readFileSync: () => '// MIKRODASH_PATCHED_MULTI_BLOCK_V2\n',
+    log: { error() {} },
+  }), /MULTI_BLOCK.*not found/i);
+});
+
+test('the currently installed patched node-routeros passes the runtime verifier', () => {
+  const { verifyRouterOSPatchMarkers } = require('../src/routeros/patchVerification');
+  assert.doesNotThrow(() => verifyRouterOSPatchMarkers({ readFileSync: fs.readFileSync }));
+});
+
+test('Docker copies the shared patch verifier before running the dependency patch', () => {
+  const dockerfile = fs.readFileSync(path.join(__dirname, '..', 'Dockerfile'), 'utf8');
+  const verifierCopy = dockerfile.indexOf('COPY src/routeros/patchVerification.js ./src/routeros/patchVerification.js');
+  const patchCopy = dockerfile.indexOf('COPY patch-routeros.js ./');
+  const patchRun = dockerfile.indexOf('RUN node patch-routeros.js');
+  const fullCopy = dockerfile.indexOf('COPY . .');
+  assert.ok(verifierCopy >= 0, 'the verifier is present in the cached dependency layer');
+  assert.ok(verifierCopy < patchCopy && patchCopy < patchRun,
+    'both patch files exist before the patch script runs');
+  assert.ok(patchRun < fullCopy, 'the full source tree is not copied early and dependency caching is retained');
+});
+
+test('the dependency patch command exits nonzero when required files are absent', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'mikrodash-patch-fail-'));
+  try {
+    fs.mkdirSync(path.join(temp, 'src', 'routeros'), { recursive: true });
+    fs.mkdirSync(path.join(temp, 'node_modules', 'node-routeros', 'dist'), { recursive: true });
+    fs.copyFileSync(path.join(__dirname, '..', 'patch-routeros.js'), path.join(temp, 'patch-routeros.js'));
+    fs.copyFileSync(path.join(__dirname, '..', 'src', 'routeros', 'patchVerification.js'),
+      path.join(temp, 'src', 'routeros', 'patchVerification.js'));
+    const result = spawnSync(process.execPath, ['patch-routeros.js'], { cwd: temp, encoding: 'utf8' });
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout + result.stderr, /FAILED.*refusing to continue/i);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
 });
 
 test('ROS write timeout closes the active connection before rejecting', async () => {

--- a/test/routeros-encoding.test.js
+++ b/test/routeros-encoding.test.js
@@ -22,7 +22,7 @@ const ROS = require('../src/routeros/client');
 const { PATCH_MARKERS, resolveDistPath } = require('../src/routeros/patchVerification');
 
 const ROOT = path.join(__dirname, '..');
-const patchSource = fs.readFileSync(path.join(ROOT, 'patch-routeros.js'), 'utf8');
+const patchSource = fs.readFileSync(path.join(ROOT, 'patch-routeros.js'), 'utf8').replace(/\r\n/g, '\n');
 
 /** Every `replace:` string in patch-routeros.js — what it WRITES, not what it looks for. */
 const replacements = patchSource
@@ -88,7 +88,10 @@ test('every verified marker is actually written by patch-routeros.js', () => {
   // server refused to start until the two agreed again.
   for (const marker of PATCH_MARKERS) {
     const description = marker.replace('MIKRODASH_PATCHED_', '');
-    assert.ok(patchSource.includes(`'${description}'`),
+    const genericPatch = patchSource.includes(`'${description}'`)
+      && patchSource.includes("'MIKRODASH_PATCHED_' + description");
+    const dedicatedPatch = patchSource.includes(marker);
+    assert.ok(genericPatch || dedicatedPatch,
       `${marker} is verified at startup but patch-routeros.js writes no such patch`);
   }
 });


### PR DESCRIPTION
## Problem
`patch-routeros.js` currently applies seven compatibility patches, but startup verifies only four markers. The patch command also returns success when a required file or replacement target is missing. A dependency layout change can therefore produce a Docker image that built successfully while `EMPTY_NO_CLOSE`, `MULTI_BLOCK`, or `MULTI_BLOCK_V2` is absent.

There is a second edge case: substring matching lets the `MULTI_BLOCK_V2` marker satisfy a check for `MULTI_BLOCK`.

## Fix
- Make the shared verifier require all seven compatibility markers in their actual files.
- Match marker tokens exactly, so V2 cannot stand in for V1.
- Make the patch command exit nonzero on a missing file, target, marker, or required patched behavior.
- Copy the shared verifier into the Docker dependency layer before running the patch command.
- Add regressions for the complete marker set, exact-token matching, Docker ordering, runtime verification, and a real nonzero patch-command failure.

## Verification
- Fresh `npm ci --ignore-scripts`, followed by `node patch-routeros.js`: all seven patches applied and verified.
- `node --test test/production-resilience-regressions.test.js test/routeros-encoding.test.js`: 22 passed.
- Direct ESLint on changed JS files: 0 errors.
- `git diff --check`: passed.

Note: the base branch currently has six unrelated `no-undef` lint errors for the missing page-local `setStatus` handlers; those are addressed separately in #112.